### PR TITLE
Rebuild against libabseil and protobuf

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,3 @@
 task_timeout: 54000
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/bazel-feedstock/pr26/0922908

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -83,6 +83,7 @@ if [[ "${target_platform}" == osx-* ]]; then
   export LDFLAGS="${LDFLAGS} -lz -framework CoreFoundation -Xlinker -undefined -Xlinker dynamic_lookup"
   # Remove DEVELOPER_DIR from .bazelrc
   sed -i.bak '/DEVELOPER_DIR=\/Applications\/Xcode.app/d' .bazelrc
+  sed -i '/noenable_bzlmod/a common --enable_workspace' .bazelrc
 
   # Force Bazel to use the conda C++ toolchain instead of Bazel’s Apple toolchain.
   export BAZEL_NO_APPLE_CPP_TOOLCHAIN=1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -26,3 +26,5 @@ c_compiler_version:        # [win]
   - 20                     # [win]
 cxx_compiler_version:      # [win]
   - 20                     # [win]
+zlib:
+  - '1.3'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,7 +86,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}                 # [cuda_compiler_version != "None"]
-    - bazel 7.*
+    - bazel 8.*
     # v0.2.0b1 contains patchelf support, see https://github.com/AnacondaRecipes/bazel-toolchain-feedstock/pull/3
     - bazel-toolchain >=0.2.0b1  # [not win]
     - libgrpc {{ libgrpc }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.20.0" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}
@@ -62,7 +62,7 @@ build:
   skip: true  # [py<310 or py>313]
   skip: true  # [skip_cuda_pbp and (gpu_variant or "").startswith('cuda')]
   # TODO re-enable windows once PBP can handle symlinks again. 
-  skip: true  # [win]
+  # skip: true  # [win]
 
 requirements:
   build:
@@ -368,7 +368,7 @@ outputs:
         - tensorflow
 
 about:
-  home: https://www.tensorflow.org/
+  home: https://www.tensorflow.org
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.20.0" %}
-{% set build = 2 %}
+{% set version = "2.21.0.rc0" %}
+{% set build = 0 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}
@@ -16,7 +16,7 @@ package:
 
 source:
   - url: https://github.com/tensorflow/tensorflow/archive/refs/tags/v{{ version.replace(".rc", "-rc") }}.tar.gz
-    sha256: a640d1f97be316a09301dfc9347e3d929ad4d9a2336e3ca23c32c93b0ff7e5d0
+    sha256: 91b2c2d12f0ebd78d84e5e1401269d0e6e36db5b74e19cc929e0f012b380af39
     patches:
       - patches/0001-loosen-requirements.patch
       - patches/0002-Add-constraint-to-pybind11-systemlib.patch  # [not win]


### PR DESCRIPTION
tensorflow 2.20.0

**Destination channel:** defaults

### Links

- [PKG-12377](https://anaconda.atlassian.net/browse/PKG-12377) 
- [Upstream repository](https://github.com/tensorflow/tensorflow/tree/v2.20.0)

### Explanation of changes:
- New build number


[PKG-12377]: https://anaconda.atlassian.net/browse/PKG-12377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ