### PR TITLE
Rebuild with latest protobuf/abseil/grpc

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 task_timeout: 54000
-
-channels:
-  - https://staging.continuum.io/pbp/fs/bazel-feedstock/pr27/9cfd78e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,4 @@
 task_timeout: 54000
+
+channels:
+  - https://staging.continuum.io/pbp/fs/bazel-feedstock/pr27/9cfd78e

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -306,6 +306,8 @@ echo 'build:linux --linkopt=-labsl_leak_check' >> .bazelrc
 echo 'build:linux --host_linkopt=-labsl_leak_check' >> .bazelrc
 echo 'build:linux --linkopt=-labsl_int128' >> .bazelrc
 echo 'build:linux --host_linkopt=-labsl_int128' >> .bazelrc
+echo 'build:linux --linkopt=-lre2' >> .bazelrc
+echo 'build:linux --host_linkopt=-lre2' >> .bazelrc
 
 # build using bazel
 bazel ${BAZEL_STARTUP_OPTS} build ${BAZEL_BUILD_OPTS} ${BUILD_TARGET}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,8 +39,6 @@ export TF_PYTHON_VERSION=$PY_VER
 # TODO(check):
 # absl_py
 # com_github_googleapis_googleapis
-# Needs c++17, try on linux
-#  com_googlesource_code_re2
 export TF_SYSTEM_LIBS="
   astor_archive
   astunparse_archive
@@ -49,6 +47,7 @@ export TF_SYSTEM_LIBS="
   com_google_absl
   com_google_protobuf
   com_github_grpc_grpc
+  com_googlesource_code_re2
   curl
   cython
   dill_archive

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,7 +12,7 @@ zip_keys:                      # [(linux and x86_64)]
     - cuda_compiler_version    # [(linux and x86_64)]
 
 skip_cuda_pbp:
-  - true
+  - false
 
 OSX_SDK_VER:               # [osx]
   - 12.3                   # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.20.0" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}
@@ -55,14 +55,13 @@ source:
       - patches/0029-consolidated-protobuf-unvendoring.patch     # [not win]
       - patches/0030-Disable-profiler.patch  # [not win]
       - patches/0031-xla_hlo_passes_rename.patch  # [(cuda_compiler_version or "").startswith("12")]
+      - patches/0032-add-missing-string-include.patch
 build:
   number: {{ build }}
   skip: true  # [python_impl == 'pypy']
   # https://www.tensorflow.org/install/source#tested_build_configurations
   skip: true  # [py<310 or py>313]
   skip: true  # [skip_cuda_pbp and (gpu_variant or "").startswith('cuda')]
-  # TODO re-enable windows once PBP can handle symlinks again. 
-  skip: true  # [win]
 
 requirements:
   build:
@@ -88,7 +87,7 @@ requirements:
     - {{ compiler('cuda') }}                 # [cuda_compiler_version != "None"]
     - bazel 7.*
     # v0.2.0b1 contains patchelf support, see https://github.com/AnacondaRecipes/bazel-toolchain-feedstock/pull/3
-    - bazel-toolchain >=0.2.0b1  # [not win]
+    - bazel-toolchain 0.3.2  # [not win]
     - libgrpc {{ libgrpc }}
     # Protobuf is still vendored on windows. 
     - libprotobuf {{ libprotobuf }}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,6 +91,7 @@ requirements:
     - libgrpc {{ libgrpc }}
     # Protobuf is still vendored on windows. 
     - libprotobuf {{ libprotobuf }}  # [not win]
+    - re2                                    # [not win]
     - nasm 2.14                              # [x86_64]
     - patchelf   # [unix]
     - sed        # [unix]
@@ -153,6 +154,7 @@ requirements:
     - openssl {{ openssl }}
     - pybind11 2
     - sqlite {{ sqlite }}
+    - re2 {{ re2 }} # [not win]
     # snappy needs rtti enabled, this version of ours has it
     - snappy 1.2.1
     - zlib {{ zlib }}
@@ -234,6 +236,7 @@ outputs:
         - libprotobuf-python-headers {{ libprotobuf }}  # [not win]
         - openssl {{ openssl }}
         - pybind11 2
+        - re2 {{ re2 }} # [not win]
         # snappy needs rtti enabled, this version of ours has it
         - snappy 1.2.1
         - sqlite {{ sqlite }}

--- a/recipe/patches/0021-consolidated-abseil-unvendoring.patch
+++ b/recipe/patches/0021-consolidated-abseil-unvendoring.patch
@@ -535,7 +535,7 @@ diff --git a/third_party/xla/third_party/absl/system.absl.strings.BUILD b/third_
 index fa9a7a84f67..4fb9a61299a 100644
 --- a/third_party/xla/third_party/absl/system.absl.strings.BUILD
 +++ b/third_party/xla/third_party/absl/system.absl.strings.BUILD
-@@ -17,16 +17,28 @@ cc_library(
+@@ -17,16 +17,27 @@ cc_library(
  
  cc_library(
      name = "internal",
@@ -549,7 +549,6 @@ index fa9a7a84f67..4fb9a61299a 100644
  
 +cc_library(
 +    name = "string_view",
-+    linkopts = ["-labsl_string_view"],
 +    deps = [
 +        "//absl/base",
 +        "//absl/base:config",

--- a/recipe/patches/0032-add-missing-string-include.patch
+++ b/recipe/patches/0032-add-missing-string-include.patch
@@ -1,0 +1,22 @@
+From a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0 Fri Mar 6 10:00:00 2026
+From: Eric Lundby <Eric.Lundby@gmail.com>
+Date: Fri, 6 Mar 2026 10:00:00 -0700
+Subject: [PATCH] Add missing #include <string> to custom_call_status_internal.h
+
+Newer libc++ no longer transitively includes <string> through <optional>.
+
+---
+ third_party/xla/xla/service/custom_call_status_internal.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/third_party/xla/xla/service/custom_call_status_internal.h b/third_party/xla/xla/service/custom_call_status_internal.h
+--- a/third_party/xla/xla/service/custom_call_status_internal.h
++++ b/third_party/xla/xla/service/custom_call_status_internal.h
+@@ -18,6 +18,7 @@
+ #define XLA_SERVICE_CUSTOM_CALL_STATUS_INTERNAL_H_
+ 
+ #include <optional>
++#include <string>
+ 
+ #include "absl/strings/string_view.h"
+ #include "xla/service/custom_call_status.h"

--- a/recipe/patches/0032-add-missing-string-include.patch
+++ b/recipe/patches/0032-add-missing-string-include.patch
@@ -20,3 +20,16 @@ diff --git a/third_party/xla/xla/service/custom_call_status_internal.h b/third_p
  
  #include "absl/strings/string_view.h"
  #include "xla/service/custom_call_status.h"
+
+diff --git a/third_party/xla/xla/backends/profiler/gpu/nvtx_utils.h b/third_party/xla/xla/backends/profiler/gpu/nvtx_utils.h
+index 9f253659957..059e1a3e517 100644
+--- a/third_party/xla/xla/backends/profiler/gpu/nvtx_utils.h
++++ b/third_party/xla/xla/backends/profiler/gpu/nvtx_utils.h
+@@ -18,6 +18,7 @@ limitations under the License.
+ 
+ #include <stack>
+ 
++#include <string>
+ #include "absl/strings/string_view.h"
+ #include "tsl/platform/macros.h"
+ 


### PR DESCRIPTION
tensorflow v2.20 protobuf rebuild

Destination channel: defaults

- [PKG-12377](https://anaconda.atlassian.net/browse/PKG-12377) 
- [Upstream repository](https://github.com/tensorflow/tensorflow/tree/v2.20.0)
- Relevant dependency PRs:
   - https://github.com/AnacondaRecipes/bazel-feedstock/pull/27
   
### Explanation of changes:
- Update 0021 patch to remove link flag no longer present in abseil
- Adds patch 0032 to add missing include
- Un-vendor re2, prevents need for additional patches
- Enable CUDA builds on PBP
- Enable windows builds on PBP
- Pin the bazel-toolchain dependency to the latest that works with bazel 7


[PKG-12377]: https://anaconda.atlassian.net/browse/PKG-12377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ